### PR TITLE
test: fix tests not running in Node 10

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
 	displayName: 'ts-jest',
 	preset: 'ts-jest',
 	testEnvironment: 'node',
-	testMatch: ['<rootDir>/test/*.test.ts']
+	testMatch: ['<rootDir>/test/*.test.ts'],
+	setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts']
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@types/rollup-plugin-progress": "^1.1.0",
 		"@typescript-eslint/eslint-plugin": "^2.15.0",
 		"@typescript-eslint/parser": "^2.15.0",
+		"array-flat-polyfill": "^1.0.1",
 		"eslint": "^6.8.0",
 		"husky": "^4.0.6",
 		"jest": "^24.9.0",

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,0 +1,2 @@
+// Flatmap polyfill for older NodeJS versions
+import 'array-flat-polyfill';

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,6 +689,11 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
+array-flat-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
+  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"


### PR DESCRIPTION
Funny joke NodeJS, I see what you did there.

Click link or TL;DR: test uses a `Array#flatMap` which is not available in Node10 so I quickly added the polyfill to devdepdenencies and ensure it is loaded pre-test.

https://github.com/gc/confusables/commit/1cee1e1e705484b71c03296a2214e14185dc9ecf/checks?check_suite_id=396712947

I could not have found that locally unless I switched to Node 10.